### PR TITLE
Update run_workflow.py - fix implicit dependency

### DIFF
--- a/run_workflow.py
+++ b/run_workflow.py
@@ -1,7 +1,7 @@
 # @@@SNIPSTART python-project-template-run-workflow-hello-world
 import asyncio
 
-from run_worker import SayHello
+from workflows import SayHello
 from temporalio.client import Client
 
 


### PR DESCRIPTION
## What was changed
Fixing import for the workflow class to overcome the implicit dependency.

## Why?
Though importing "SayHello" from "run_worker" works fine because "run_worker" already has the "SayHello" class imported from "workflows", having such indirect import is not a good practice and introduces more coupling.

It is kind of an implicit dependency that should not exist.

## Checklist
1. Closes: N/A (small change)

2. How was this tested:
Executed `run_worker.py` and `run_workflow.py` in separate terminals.

3. Any docs updates needed?
Code snippet corresponding to the [Workflow Execution](https://learn.temporal.io/getting_started/python/hello_world_in_python/#write-code-to-start-a-workflow-execution) documentation should be updated.
